### PR TITLE
Use PathBuf to allow tests to work on windows

### DIFF
--- a/graphql-parser/tests/query_errors.rs
+++ b/graphql-parser/tests/query_errors.rs
@@ -3,12 +3,15 @@ extern crate graphql_parser;
 
 use std::io::Read;
 use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
 
 use graphql_parser::parse_query;
 
 fn test_error(filename: &str) {
     let mut buf = String::with_capacity(1024);
     let path = format!("tests/query_errors/{}.txt", filename);
+    let path = PathBuf::from(&path);
     let mut f = File::open(&path).unwrap();
     f.read_to_string(&mut buf).unwrap();
     let mut iter = buf.splitn(2, "\n---\n");

--- a/graphql-parser/tests/query_errors.rs
+++ b/graphql-parser/tests/query_errors.rs
@@ -1,7 +1,6 @@
 extern crate graphql_parser;
 #[cfg(test)] #[macro_use] extern crate pretty_assertions;
 
-use std::io::Read;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;


### PR DESCRIPTION
PathBuf normalizes the seperator of the path to be platform specific (I
think) allowing just this test suite to run on windows (I expect others
to fail)