### PR TITLE
Normalize line endings across platforms

### DIFF
--- a/graphql-parser/tests/query_errors.rs
+++ b/graphql-parser/tests/query_errors.rs
@@ -11,6 +11,7 @@ fn test_error(filename: &str) {
     let path = format!("tests/query_errors/{}.txt", filename);
     let mut f = File::open(&path).unwrap();
     f.read_to_string(&mut buf).unwrap();
+    let buf = buf.replace("\r\n", "\n");
     let mut iter = buf.splitn(2, "\n---\n");
     let graphql = iter.next().unwrap();
     let expected = iter.next().expect("file should contain error message");

--- a/graphql-parser/tests/query_roundtrips.rs
+++ b/graphql-parser/tests/query_roundtrips.rs
@@ -11,6 +11,7 @@ fn roundtrip(filename: &str) {
     let path = format!("tests/queries/{}.graphql", filename);
     let mut f = File::open(&path).unwrap();
     f.read_to_string(&mut buf).unwrap();
+    let buf = buf.replace("\r\n", "\n");
     let ast = parse_query::<String>(&buf).unwrap().to_owned();
     assert_eq!(ast.to_string(), buf);
 }
@@ -26,6 +27,7 @@ fn roundtrip2(filename: &str) {
     let mut buf = String::with_capacity(1024);
     let mut f = File::open(&target).unwrap();
     f.read_to_string(&mut buf).unwrap();
+    let buf = buf.replace("\r\n", "\n");
     assert_eq!(ast.to_string(), buf);
 }
 

--- a/graphql-parser/tests/schema_roundtrips.rs
+++ b/graphql-parser/tests/schema_roundtrips.rs
@@ -11,6 +11,7 @@ fn roundtrip(filename: &str) {
     let path = format!("tests/schemas/{}.graphql", filename);
     let mut f = File::open(&path).unwrap();
     f.read_to_string(&mut buf).unwrap();
+    let buf = buf.replace("\r\n", "\n");
     let ast = parse_schema::<String>(&buf).unwrap().to_owned();
     assert_eq!(ast.to_string(), buf);
 }
@@ -21,11 +22,13 @@ fn roundtrip2(filename: &str) {
     let target = format!("tests/schemas/{}_canonical.graphql", filename);
     let mut f = File::open(&source).unwrap();
     f.read_to_string(&mut buf).unwrap();
+    let buf = buf.replace("\r\n", "\n");
     let ast = parse_schema::<String>(&buf).unwrap();
 
     let mut buf = String::with_capacity(1024);
     let mut f = File::open(&target).unwrap();
     f.read_to_string(&mut buf).unwrap();
+    let buf = buf.replace("\r\n", "\n");
     assert_eq!(ast.to_string(), buf);
 }
 


### PR DESCRIPTION
The `graphql-parser` crate uses a fixture based test suite. The problem we encountered was new lines are rendered differently on platforms (windows vs *nix). On windows new lines can be rendered as `\r\n\` but the test suite was trying to split or compare on strings with the only assumed line ending being `\n`. This puts in a coarse grain normalizer to get the windows suite working.